### PR TITLE
feat(gateway): test config + fallback, stub i rls/ retry rute + strin…

### DIFF
--- a/gateway/src/test/java/com/teamnest/gateway/config/CbFallbackHandler.java
+++ b/gateway/src/test/java/com/teamnest/gateway/config/CbFallbackHandler.java
@@ -1,0 +1,26 @@
+package com.teamnest.gateway.config;
+
+import static com.teamnest.gateway.constant.StringConstant.DOWNSTREAM_FAILURE;
+import static com.teamnest.gateway.constant.StringConstant.SERVICE_UNAVAILABLE;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+class CbFallbackHandler {
+
+    @RequestMapping("/__cb-fallback__")
+    public ResponseEntity<ProblemDetail> fallback() {
+        ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.SERVICE_UNAVAILABLE);
+        pd.setTitle(SERVICE_UNAVAILABLE);
+        pd.setDetail(DOWNSTREAM_FAILURE);
+        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+            .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+            .body(pd);
+    }
+}

--- a/gateway/src/test/java/com/teamnest/gateway/config/TestMessageSourceConfig.java
+++ b/gateway/src/test/java/com/teamnest/gateway/config/TestMessageSourceConfig.java
@@ -1,0 +1,35 @@
+package com.teamnest.gateway.config;
+
+import static com.teamnest.gateway.constant.StringConstant.*;
+
+import java.util.Locale;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.MessageSource;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.support.StaticMessageSource;
+
+@TestConfiguration
+public class TestMessageSourceConfig {
+
+    private static final Locale LOCALE_EN = Locale.ENGLISH;
+    private static final Locale LOCALE_SR = Locale.forLanguageTag(SR_LANGUAGE); // "sr", ili "sr-Latn"/"sr-Cyrl" po potrebi
+
+    @Bean
+    MessageSource messageSource() {
+        var sms = new StaticMessageSource();
+        sms.setUseCodeAsDefaultMessage(true);
+
+        // 429
+        sms.addMessage("error.rateLimit", LOCALE_EN, TO_MANY_REQUESTS);
+        sms.addMessage("error.rateLimit", LOCALE_SR, TO_MANY_REQUESTS_SR);
+
+        // 401
+        sms.addMessage("error.auth.failed", LOCALE_EN, "Authentication failed");
+
+        // 500
+        sms.addMessage("error.internal", LOCALE_EN, UNEXPECTED_ERROR);
+        sms.addMessage("error.internal", LOCALE_SR, UNEXPECTED_ERROR_SR);
+
+        return sms;
+    }
+}

--- a/gateway/src/test/java/com/teamnest/gateway/config/TestRedisConfig.java
+++ b/gateway/src/test/java/com/teamnest/gateway/config/TestRedisConfig.java
@@ -1,0 +1,25 @@
+package com.teamnest.gateway.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.env.Environment;
+import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
+
+@TestConfiguration(proxyBeanMethods = false)
+public class TestRedisConfig {
+
+    @Bean
+    public ReactiveRedisConnectionFactory reactiveRedisConnectionFactory(Environment env) {
+        String host = env.getRequiredProperty("spring.data.redis.host");
+        int port = Integer.parseInt(env.getRequiredProperty("spring.data.redis.port"));
+        return new LettuceConnectionFactory(new RedisStandaloneConfiguration(host, port));
+    }
+
+    @Bean
+    public ReactiveStringRedisTemplate reactiveStringRedisTemplate(ReactiveRedisConnectionFactory factory) {
+        return new ReactiveStringRedisTemplate(factory);
+    }
+}

--- a/gateway/src/test/java/com/teamnest/gateway/config/TestRoutesCircuitBreaker.java
+++ b/gateway/src/test/java/com/teamnest/gateway/config/TestRoutesCircuitBreaker.java
@@ -1,0 +1,35 @@
+package com.teamnest.gateway.config;
+
+import java.io.IOException;
+import okhttp3.mockwebserver.MockWebServer;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.cloud.gateway.route.RouteLocator;
+import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class TestRoutesCircuitBreaker {
+
+    @Bean(destroyMethod = "shutdown")
+    MockWebServer mockWebServer() throws IOException {
+        MockWebServer mws = new MockWebServer();
+        mws.start(); // ephemeral port
+        return mws;
+    }
+
+    @Bean
+    RouteLocator testRoutes(RouteLocatorBuilder builder, MockWebServer mws) {
+        String base = mws.url("/").toString(); // e.g. http://127.0.0.1:54321/
+        return builder.routes()
+            .route("cb_always500", r -> r.path("/cb/always500/**")
+                .filters(f -> f
+                    .rewritePath("/cb/always500/(?<segment>.*)", "/users")
+                    .circuitBreaker(c -> c
+                        .setName("usersCB")
+                        .setFallbackUri("forward:/__cb-fallback__")
+                        .addStatusCode("500") // tretiraj 5xx kao failure
+                    ))
+                .uri(base))
+            .build();
+    }
+}

--- a/gateway/src/test/java/com/teamnest/gateway/config/TestRoutesRateLimit.java
+++ b/gateway/src/test/java/com/teamnest/gateway/config/TestRoutesRateLimit.java
@@ -1,0 +1,28 @@
+package com.teamnest.gateway.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.cloud.gateway.filter.ratelimit.RedisRateLimiter;
+import org.springframework.cloud.gateway.route.RouteLocator;
+import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class TestRoutesRateLimit {
+    @Bean RedisRateLimiter testRedisRateLimiter() { return new RedisRateLimiter(1, 1); }
+
+    @Bean
+
+    RouteLocator rlRoutes(RouteLocatorBuilder rlb,
+                          KeyResolverConfig resolvers,
+                          RedisRateLimiter testRedisRateLimiter) {
+        return rlb.routes()
+            .route("rl-basic", r -> r
+                .path("/rl/test/**")
+                .filters(f -> f.requestRateLimiter(c -> {
+                    c.setKeyResolver(resolvers.principalOrIpKeyResolver());
+                    c.setRateLimiter(testRedisRateLimiter);
+                }))
+                .uri("forward:/__stub/flaky-twice-then-ok"))
+            .build();
+    }
+}

--- a/gateway/src/test/java/com/teamnest/gateway/config/TestRoutesRetry.java
+++ b/gateway/src/test/java/com/teamnest/gateway/config/TestRoutesRetry.java
@@ -1,0 +1,38 @@
+// src/test/java/com/teamnest/gateway/config/TestRoutesRetry.java
+package com.teamnest.gateway.config;
+
+import java.time.Duration;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.cloud.gateway.route.RouteLocator;
+import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.env.Environment;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.util.Assert;
+
+@TestConfiguration
+public class TestRoutesRetry {
+
+    @Bean
+    RouteLocator testRoutes(RouteLocatorBuilder rlb, Environment env) {
+        String target = env.getProperty("gateway.test.retryTarget");
+        Assert.hasText(target, "Missing property gateway.test.retryTarget (WireMock baseUrl)");
+
+        return rlb.routes()
+            .route("retry-downstream", r -> r
+                .path("/retry/**")
+                .filters(f -> f
+                    .stripPrefix(1)
+                    .retry(cfg -> {
+                        cfg.setRetries(2);
+                        cfg.setMethods(HttpMethod.GET);
+                        cfg.setSeries(HttpStatus.Series.SERVER_ERROR);
+                        cfg.setBackoff(Duration.ofMillis(20), Duration.ofMillis(100), 2, false);
+                    })
+                )
+                .uri(target)
+            )
+            .build();
+    }
+}

--- a/gateway/src/test/java/com/teamnest/gateway/config/TestSecurityConfig.java
+++ b/gateway/src/test/java/com/teamnest/gateway/config/TestSecurityConfig.java
@@ -1,0 +1,22 @@
+package com.teamnest.gateway.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+
+@Configuration
+@Profile("test")
+public class TestSecurityConfig {
+
+    @Bean
+    SecurityWebFilterChain testSecurity(ServerHttpSecurity http) {
+        return http
+            .csrf(ServerHttpSecurity.CsrfSpec::disable)
+            .authorizeExchange(a -> a.anyExchange().permitAll())
+            .build();
+    }
+}

--- a/gateway/src/test/java/com/teamnest/gateway/constant/StringConstant.java
+++ b/gateway/src/test/java/com/teamnest/gateway/constant/StringConstant.java
@@ -1,0 +1,151 @@
+package com.teamnest.gateway.constant;
+
+/**
+ * Centralizovane test konstante (putanje, header-i, JWT claims, poruke, statusi...).
+ * Napomena: nazivi i vrednosti su zadržani kako bi ostali kompatibilni sa postojećim testovima.
+ */
+public final class StringConstant {
+
+    private StringConstant() { /* no-op */ }
+
+    // ---------------------------------------------------------------------
+    // URLs / PATHS
+    // ---------------------------------------------------------------------
+    public static final String CB_ALWAYS_500_URL     = "/cb/always500/test";
+    public static final String TEST_RLS_URL          = "/__test/rls";
+    public static final String TEST_INTERNAL_URL     = "/__test/internal";
+    public static final String R1_TEST_ONE           = "/rl/test/one";
+    public static final String R1_TEST_TWO           = "/rl/test/two";
+    public static final String FLAKY_TEST_URL        = "/flaky/test";
+    public static final String RETRY_FLAKY_TEST_URL  = "/retry/flaky/test";
+    public static final String PATH_LOGIN            = "/login";
+    public static final String PATH_DOCS_PING        = "/docs/ping";
+    public static final String PATH_FALLBACK_PING    = "/__fallback/ping";
+    public static final String PATH_PROTECTED        = "/protected";
+    public static final String PATH_SECURE           = "/secure";
+    public static final String PATH_SVC              = "/svc";
+    public static final String PATH_ANY              = "/any";
+    public static final String PATH_X                = "/x";
+    public static final String PATH_Y                = "/y";
+    public static final String PATH_Z                = "/z";
+    public static final String PATH_P                = "/z"; // zadržano kao u originalu
+    public static final String PATH_RATE_LIMITED     = "/ratelimited";
+
+    // Sample IP adrese
+    public static final String PATH_LOCAL_IP         = "127.0.0.1";
+    public static final String PATH_IO               = "203.0.113.10";
+
+    // ---------------------------------------------------------------------
+    // BODY PAYLOADS
+    // ---------------------------------------------------------------------
+    public static final String OK_AFTER_RETRIES      = "ok-after-retries";
+    public static final String BODY_OK               = "ok";
+
+    // ---------------------------------------------------------------------
+    // JWT / ROLES / CLAIMS
+    // ---------------------------------------------------------------------
+    // JWT header
+    public static final String JWT_TOKEN_VALUE       = "t";
+    public static final String JWT_HEADER_ALG        = "alg";
+    public static final String JWT_ALG_NONE          = "none";
+    public static final String CID_1 = "cid-1";
+
+    // Claims
+    public static final String CLAIM_ROLES           = "roles";
+    public static final String CLAIM_REALM_ACCESS    = "realm_access";
+    public static final String CLAIM_REALM_ACCESS_ROLES = "roles";
+    public static final String CLAIM_OTHER_KEY       = "club_id";
+    public static final String CLAIM_OTHER_VAL       = "adasdadaas";
+
+    // Ulazne role (iz tokena)
+    public static final String ROLE_ADMIN            = "admin";        // bez prefixa
+    public static final String ROLE_MANAGER          = "ROLE_manager"; // već sa prefixom
+    public static final String ROLE_USER             = "user";
+    public static final String ROLE_SUPER            = "super";
+
+    // Očekivane authorities
+    public static final String AUTH_ROLE_PREFIX      = "ROLE_";
+    public static final String AUTH_ROLE_ADMIN       = "ROLE_admin";
+    public static final String AUTH_ROLE_MANAGER     = "ROLE_manager";
+    public static final String AUTH_ROLE_USER        = "ROLE_user";
+    public static final String AUTH_ROLE_SUPER       = "ROLE_super";
+
+    // ---------------------------------------------------------------------
+    // REQUEST IDS
+    // ---------------------------------------------------------------------
+    public static final String RID_123               = "rid-123";
+    public static final String RID_999               = "rid-999";
+    public static final String RID_1                 = "rid-1";
+    public static final String RID_X                 = "rid-x";
+    public static final String RID_REQ               = "rid-req";
+    public static final String RID_429               = "rid-429";
+    public static final String RID_COMM              = "rid-committed";
+    public static final String RID_42                = "rid-42";
+    public static final String GIVEN_1               = "given-1";
+
+    // ---------------------------------------------------------------------
+    // HEADERS
+    // ---------------------------------------------------------------------
+    public static final String X_REQUEST_ID          = "X-Request-Id";
+    public static final String X_FORWARDED_FOR       = "X-Forwarded-For";
+    public static final String RETRY_AFTER_SECONDS   = "5";
+    public static final String CORRELATION_ID        = "correlationId";
+
+    // ---------------------------------------------------------------------
+    // JSON PATH KEYS
+    // ---------------------------------------------------------------------
+    public static final String TITLE                 = "$.title";
+    public static final String STATUS                = "$.status";
+
+    // ---------------------------------------------------------------------
+    // MISC / STRINGS
+    // ---------------------------------------------------------------------
+    public static final String ANONYMOUS             = "anonymous";
+    public static final String X_DETAIL              = "x-detail";
+    public static final String DETAIL_BAD            = "bad";
+    public static final String NOPE                  = "nope";
+    public static final String ALICE                 = "alice";
+    public static final String X                     = "x";
+    public static final String DETAIL_OOPS           = "oops";
+    public static final String DETAIL_H2             = "h2";
+    public static final String HINT                  = "hint";
+    public static final String FLAKY                 = "flaky";
+    public static final String STEP_2                = "step2";
+    public static final String OK                    = "ok";
+
+    // ---------------------------------------------------------------------
+    // I18N / MESSAGES
+    // ---------------------------------------------------------------------
+    public static final String EN_LANGUAGE           = "en";
+    public static final String SR_LANGUAGE           = "sr";
+    public static final String SERVICE_UNAVAILABLE   = "Service Unavailable";
+    public static final String DOWNSTREAM_FAILURE    = "Downstream failure";
+    public static final String BOOM                  = "boom";
+    public static final String TO_MANY_REQUESTS      = "Too many requests";     // zadržan naziv konstante
+    public static final String TO_MANY_REQUESTS_SR   = "Previše zahteva";
+    public static final String UNEXPECTED_ERROR      = "Unexpected error";
+    public static final String UNEXPECTED_ERROR_SR   = "Neočekivana greška";
+    public static final String RATE_LIMIT_EXCEEDED   = "Rate limit exceeded";
+
+    // ---------------------------------------------------------------------
+    // HTTP STATUS (numeric)
+    // ---------------------------------------------------------------------
+    public static final int HTTP_STATUS_200          = 200;
+    public static final int HTTP_STATUS_429          = 429;
+    public static final int HTTP_STATUS_503          = 503;
+    public static final int HTTP_STATUS_500          = 500;
+
+    // ---------------------------------------------------------------------
+    // Problem JSON common properties
+    // ---------------------------------------------------------------------
+    public static final String ERROR_CODE            = "errorCode";
+    public static final String APP                   = "app";
+    public static final String GATEWAY               = "gateway";
+    public static final String REQUEST_ID            = "requestId";
+
+    // ---------------------------------------------------------------------
+    // DISPLAY NAMES
+    // ---------------------------------------------------------------------
+    public static final String CIRCUIT_BREAKER       =
+        "CircuitBreaker -> fallback returns RFC7807 503 with X-Request-Id";
+}

--- a/pom.xml
+++ b/pom.xml
@@ -48,15 +48,15 @@
         <checkstyle.config.location>${maven.multiModuleProjectDirectory}/config/checkstyle/checkstyle.xml</checkstyle.config.location>
     </properties>
 
-<!--    <modules>-->
-<!--        &lt;!&ndash; shared multi-moduli &ndash;&gt;-->
-<!--        <module>shared/bom</module>-->
-<!--        <module>shared/problem</module>-->
-<!--        <module>shared/dto</module>-->
-<!--        <module>shared/test-utils</module>-->
-<!--        &lt;!&ndash; apps &ndash;&gt;-->
-<!--        <module>gateway</module>-->
-<!--    </modules>-->
+    <modules>
+        <!-- shared multi-moduli -->
+        <module>shared/bom</module>
+        <module>shared/problem</module>
+        <module>shared/dto</module>
+        <module>shared/test-utils</module>
+        <!-- apps -->
+        <module>gateway</module>
+    </modules>
 
     <!-- Verzije (BOM-ovi i lib menadžment) -->
     <dependencyManagement>


### PR DESCRIPTION
…g constants

- CbFallbackHandler: standardni 503 PROBLEM+JSON fallback (forward:/__cb-fallback__)
- TestControllers: stub endpointi za 429, 500, flaky(2x)→ok, fallback users/trainings
- TestMessageSourceConfig: poruke za rateLimit/auth/internal (en/sr)
- TestRedisConfig: ReactiveRedis + Lettuce factory/template (test profil)
- TestRoutesCircuitBreaker: MockWebServer + CB sa fallbackom za 5xx
- TestRoutesRateLimit: RedisRateLimiter + key resolver (principal/ip)
- TestRoutesRetry: retry filter (GET, 5xx, backoff) uz gateway.test.retryTarget
- TestSecurityConfig: permitAll, CSRF off (profil test)
- string constants