### PR TITLE
feat(gateway): infra tuning for performance, resilience, and observab…

### DIFF
--- a/gateway/src/main/java/com/teamnest/gateway/config/CaffeineConfig.java
+++ b/gateway/src/main/java/com/teamnest/gateway/config/CaffeineConfig.java
@@ -1,0 +1,17 @@
+package com.teamnest.gateway.config;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class CaffeineConfig {
+    @Bean(name = "staleResponses")
+    public Cache<String, byte[]> staleResponses() {
+        return com.github.benmanes.caffeine.cache.Caffeine.newBuilder()
+            .maximumSize(200)
+            .expireAfterWrite(java.time.Duration.ofSeconds(60))
+            .build();
+    }
+
+}

--- a/gateway/src/main/java/com/teamnest/gateway/config/GatewayHttpClientConfig.java
+++ b/gateway/src/main/java/com/teamnest/gateway/config/GatewayHttpClientConfig.java
@@ -1,0 +1,25 @@
+package com.teamnest.gateway.config;
+
+import io.netty.channel.ChannelOption;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import io.netty.handler.timeout.WriteTimeoutHandler;
+import java.time.Duration;
+import org.springframework.cloud.gateway.config.HttpClientCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import reactor.netty.http.client.HttpClient;
+
+@Configuration
+public class GatewayHttpClientConfig {
+
+    @Bean
+    HttpClientCustomizer gatewayHttpClientCustomizer() {
+        return (HttpClient http) -> http
+            .compress(true)
+            .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 3000)
+            .responseTimeout(Duration.ofSeconds(5))
+            .doOnConnected(conn -> conn
+                .addHandlerLast(new ReadTimeoutHandler(5))
+                .addHandlerLast(new WriteTimeoutHandler(5)));
+    }
+}

--- a/gateway/src/main/java/com/teamnest/gateway/config/KeyResolverConfig.java
+++ b/gateway/src/main/java/com/teamnest/gateway/config/KeyResolverConfig.java
@@ -1,0 +1,29 @@
+package com.teamnest.gateway.config;
+
+import static org.springframework.cloud.gateway.support.ipresolver.XForwardedRemoteAddressResolver.X_FORWARDED_FOR;
+import static org.springframework.security.config.Elements.ANONYMOUS;
+
+import java.security.Principal;
+import org.springframework.cloud.gateway.filter.ratelimit.KeyResolver;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import reactor.core.publisher.Mono;
+
+/** Resolves rate-limit key by principal if present, else by IP. */
+@Configuration
+public class KeyResolverConfig {
+
+    @Bean("principalOrIpKeyResolver")
+    public KeyResolver principalOrIpKeyResolver() {
+        return exchange -> exchange.getPrincipal()
+            .map(Principal::getName)
+            .switchIfEmpty(Mono.justOrEmpty(
+                exchange.getRequest().getHeaders().getFirst(X_FORWARDED_FOR)))
+            .switchIfEmpty(Mono.just(
+                exchange.getRequest().getRemoteAddress() != null
+                    ? exchange.getRequest().getRemoteAddress().getAddress().getHostAddress()
+                    : ANONYMOUS));
+    }
+
+
+}

--- a/gateway/src/main/java/com/teamnest/gateway/config/LoadBalancerCacheConfig.java
+++ b/gateway/src/main/java/com/teamnest/gateway/config/LoadBalancerCacheConfig.java
@@ -1,0 +1,17 @@
+package com.teamnest.gateway.config;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class LoadBalancerCacheConfig {
+    @Bean
+    public CacheManager loadBalancerCacheManager() {
+        var cm = new CaffeineCacheManager();
+        cm.setCaffeine(Caffeine.newBuilder().maximumSize(1000));
+        return cm;
+    }
+}

--- a/gateway/src/main/java/com/teamnest/gateway/config/NettyHttpClientConfig.java
+++ b/gateway/src/main/java/com/teamnest/gateway/config/NettyHttpClientConfig.java
@@ -1,0 +1,28 @@
+package com.teamnest.gateway.config;
+
+import io.netty.channel.ChannelOption;
+import java.time.Duration;
+import org.springframework.boot.web.embedded.netty.NettyReactiveWebServerFactory;
+import org.springframework.boot.web.reactive.server.ReactiveWebServerFactory;
+import org.springframework.cloud.gateway.config.HttpClientCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import reactor.netty.http.client.HttpClient;
+
+@Configuration
+public class NettyHttpClientConfig {
+
+    // Ako koristiš i embedded Netty server tuning (opciono)
+    @Bean
+    ReactiveWebServerFactory reactiveWebServerFactory() {
+        return new NettyReactiveWebServerFactory();
+    }
+
+    // Gateway HttpClient tuning – zamena za deprecated properties
+    @Bean
+    HttpClientCustomizer gatewayHttpClientTimeouts() {
+        return (HttpClient http) -> http
+            .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 3000)
+            .responseTimeout(Duration.ofSeconds(5));
+    }
+}


### PR DESCRIPTION
### **User description**
…ility

- Introduced Caffeine-based caches for stale responses and load-balancer lookups to reduce latency and improve throughput under load
- Configured Netty/HttpClient timeouts (connect, response, read, write) for predictable failure handling and faster recovery
- Added KeyResolver that prefers authenticated principal, falling back to X-Forwarded-For or remote IP, enabling fair rate-limiting for both users and anonymous clients
- Implemented CorrelationIdFilter to generate and propagate X-Correlation-Id / X-Request-Id across requests, including MDC for log tracing
- Added Reactor Context propagation support to consistently carry request IDs through reactive pipelines
- Overall, this commit strengthens gateway observability, improves client experience under failure, and enforces cross-cutting infrastructure concerns in a centralized and reusable way


___

### **PR Type**
Enhancement


___

### **Description**
- Added Caffeine-based caching for stale responses and load-balancer lookups

- Configured Netty/HttpClient timeouts for predictable failure handling

- Implemented principal-based KeyResolver with IP fallback for rate-limiting

- Enhanced gateway performance, resilience, and observability infrastructure


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Gateway Request"] --> B["KeyResolver"]
  A --> C["Caffeine Cache"]
  A --> D["HttpClient Timeouts"]
  B --> E["Principal or IP Resolution"]
  C --> F["Stale Response Cache"]
  C --> G["Load Balancer Cache"]
  D --> H["Connection/Response Timeouts"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CaffeineConfig.java</strong><dd><code>Configure Caffeine cache for stale responses</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/src/main/java/com/teamnest/gateway/config/CaffeineConfig.java

<ul><li>Creates stale response cache bean with 200 max size<br> <li> Sets 60-second expiration for cached responses</ul>


</details>


  </td>
  <td><a href="https://github.com/MarkoBozic90/TeamNest-Enterprise-Microservices-Demo/pull/17/files#diff-bd5eb7367ef1b11fc57cf6f1a3f9c4c12341d345f2085e1066e17d5a3b66cdb4">+17/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>GatewayHttpClientConfig.java</strong><dd><code>Configure gateway HTTP client timeouts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/src/main/java/com/teamnest/gateway/config/GatewayHttpClientConfig.java

<ul><li>Configures HttpClient with compression and timeouts<br> <li> Sets 3-second connect timeout and 5-second response timeout<br> <li> Adds read/write timeout handlers to connections</ul>


</details>


  </td>
  <td><a href="https://github.com/MarkoBozic90/TeamNest-Enterprise-Microservices-Demo/pull/17/files#diff-988870a7af44c547adb5690cbebe3f2f0825d23f05c9f57ce76bbe5d2c2d0097">+25/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>LoadBalancerCacheConfig.java</strong><dd><code>Configure load balancer caching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/src/main/java/com/teamnest/gateway/config/LoadBalancerCacheConfig.java

<ul><li>Creates Caffeine-based cache manager for load balancer<br> <li> Sets maximum cache size to 1000 entries</ul>


</details>


  </td>
  <td><a href="https://github.com/MarkoBozic90/TeamNest-Enterprise-Microservices-Demo/pull/17/files#diff-c0587ce68011c18a403d17d07ab6ebe9594c878da4f92f52ccbef3683326196a">+17/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>NettyHttpClientConfig.java</strong><dd><code>Configure Netty HTTP client timeouts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/src/main/java/com/teamnest/gateway/config/NettyHttpClientConfig.java

<ul><li>Configures Netty reactive web server factory<br> <li> Sets up gateway HttpClient with connection and response timeouts<br> <li> Duplicates some timeout configuration from GatewayHttpClientConfig</ul>


</details>


  </td>
  <td><a href="https://github.com/MarkoBozic90/TeamNest-Enterprise-Microservices-Demo/pull/17/files#diff-3059d4e1e5e5855916742093cedd672d4dfe3c905f9fcc1f61220517c7e26fe4">+28/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>KeyResolverConfig.java</strong><dd><code>Add principal-based key resolver for rate limiting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gateway/src/main/java/com/teamnest/gateway/config/KeyResolverConfig.java

<ul><li>Implements rate-limiting key resolver with principal preference<br> <li> Falls back to X-Forwarded-For header or remote IP<br> <li> Handles anonymous users gracefully</ul>


</details>


  </td>
  <td><a href="https://github.com/MarkoBozic90/TeamNest-Enterprise-Microservices-Demo/pull/17/files#diff-a0a827a028439e2ec1651e1640503e095e0f81eae39bff0a71c819a901c07300">+29/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

